### PR TITLE
Sort pay table to remove undefined behavior dependent logic on pay table setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,4 +179,3 @@ You can arbitrarily modify those sample files or create new ones. However be car
 
 ## TODO
 - reconstruct file structures (merge, split, hierarchy)
-- remove undefined behavior dependent logic on pay table setting: `// WARNING: property should be ordered by priority (higher first)`

--- a/calculate_rtp.ts
+++ b/calculate_rtp.ts
@@ -6,9 +6,6 @@ import { BasicPokerGame } from './src/video-poker/game';
 import { OptimalHoldTargetSelector } from './src/hold-target-selector/optimal-selector';
 import RTPCalculator from './src/rtp-caculator/rtp-calculator';
 
-// WARNING: property should be ordered by priority (higher first)
-// e.g.) JAKCS_OR_BETTER should located after FULL_HOUSE.
-// If not, FULL_HOUSE hand can be payed as if it is JACKS_OR_BETTER
 const testPayTable: IPayTitleMap<number> = {
   ROYAL_STRAIGHT_FLUSH: 250,
   STRAIGHT_FLUSH: 50,

--- a/cheated_poker_simulation.ts
+++ b/cheated_poker_simulation.ts
@@ -6,9 +6,6 @@ import { CheatedPokerGame } from './src/video-poker/game';
 import { CheatedOptimalHoldTargetSelector } from './src/hold-target-selector/optimal-selector';
 import Simulator from './src/simulator/simulator';
 
-// WARNING: property should be ordered by priority (higher first)
-// e.g.) JAKCS_OR_BETTER should located after FULL_HOUSE.
-// If not, FULL_HOUSE hand can be payed as if it is JACKS_OR_BETTER
 const testPayTable: IPayTitleMap<number> = {
   ROYAL_STRAIGHT_FLUSH: 250,
   STRAIGHT_FLUSH: 50,

--- a/src/hold-target-selector/optimal-selector.ts
+++ b/src/hold-target-selector/optimal-selector.ts
@@ -43,7 +43,10 @@ export class OptimalHoldTargetSelector implements IOptimalHoldTargetSelector {
     console.log("Start optimal selector init");
     console.log("Trying load discard value table from file");
     const hashGenerator = crypto.createHash('md5');
-    hashGenerator.update(JSON.stringify(Object.entries(this.pay_calculator.pay_table).sort((a,b) => b[1]-a[1])));
+     // use getOwnPropertyNames().sort() so different pay multiplier and order doesn't change the hash
+    hashGenerator.update(
+      JSON.stringify(Object.getOwnPropertyNames(this.pay_calculator.pay_table).sort())
+    );
     const payTableHash = hashGenerator.digest('hex');
     const fileCacheName = `filecache_${payTableHash}`;
     try {

--- a/src/hold-target-selector/optimal-selector.ts
+++ b/src/hold-target-selector/optimal-selector.ts
@@ -43,7 +43,6 @@ export class OptimalHoldTargetSelector implements IOptimalHoldTargetSelector {
     console.log("Start optimal selector init");
     console.log("Trying load discard value table from file");
     const hashGenerator = crypto.createHash('md5');
-    // use getOwnPropertyNames to guarantee string property to be ordered by its creation order
     hashGenerator.update(JSON.stringify(Object.entries(this.pay_calculator.pay_table).sort((a,b) => b[1]-a[1])));
     const payTableHash = hashGenerator.digest('hex');
     const fileCacheName = `filecache_${payTableHash}`;

--- a/src/hold-target-selector/optimal-selector.ts
+++ b/src/hold-target-selector/optimal-selector.ts
@@ -44,7 +44,7 @@ export class OptimalHoldTargetSelector implements IOptimalHoldTargetSelector {
     console.log("Trying load discard value table from file");
     const hashGenerator = crypto.createHash('md5');
     // use getOwnPropertyNames to guarantee string property to be ordered by its creation order
-    hashGenerator.update(JSON.stringify(Object.getOwnPropertyNames(this.pay_calculator.pay_table)));
+    hashGenerator.update(JSON.stringify(Object.entries(this.pay_calculator.pay_table).sort((a,b) => b[1]-a[1])));
     const payTableHash = hashGenerator.digest('hex');
     const fileCacheName = `filecache_${payTableHash}`;
     try {

--- a/src/video-poker/pay-calculator.ts
+++ b/src/video-poker/pay-calculator.ts
@@ -16,11 +16,10 @@ export default class PayCalculator implements IPayCalculator {
     this.pay_table = payTable;
     const judgeFuncMap: IPayTitleMap<IJudgeFunc> = {};
     this.judge_func_with_pay_title_array = [];
-    // use getOwnPropertyNames to guarantee string property to be ordered by its creation order
     // Note: property should be ordered by priority (higher first)
     // e.g.) JAKCS_OR_BETTER should located after FULL_HOUSE.
     // If not, FULL_HOUSE hand can be payed as if it is JACKS_OR_BETTER
-    const payTitleList = Object.getOwnPropertyNames(this.pay_table) as (keyof IPayTitleMap<number>)[];
+    const payTitleList = Object.entries(this.pay_table).sort((a,b) => b[1]-a[1]).map(([n]) => n) as (keyof IPayTitleMap<number>)[];
     for (let i = 0; i < payTitleList.length; ++i) {
       const payTitle = payTitleList[i];
       if (payTitleToJudgeFuncMap[payTitle] == null) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es6",
+        "lib": ["es2017"]
     },
     "outdir": "gen/",
     "include": [


### PR DESCRIPTION
Use `Object.entries()` to convert the pay table to an array, and then sort the array to get the pay titles ordered by higher first.

Resolves #1 